### PR TITLE
Added @rclnodejs scope to package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ref-array-di
 ============
+*THIS PACKAGE WAS FORKED FROM http://github.com/node-ffi-napi/ref-array-di AND UPDATED TO 
+ENABLE [rclnodejs](https://github.com/RobotWebTools/rclnodejs) TO RUN UNDER NODE VERSIONS 12-16. NO TESTING BEYOND the rclnodejs TEST SUITE
+HAS BEEN PERFORMED. USE AT YOUR OWN DISCRETION.*
 ### Create C typed "array" instances on top of Buffers
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/node-ffi-napi/ref-array-di.svg)](https://greenkeeper.io/)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ref-array-di",
+  "name": "@rclnodejs/ref-array-di",
   "description": "Create C \"array\" instances on top of Buffers",
   "keywords": [
     "array",
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/node-ffi-napi/ref-array-di.git"
+    "url": "git://github.com/rclnodejs/ref-array-di.git"
   },
   "main": "./lib/array.js",
   "license": "MIT",
@@ -28,6 +28,6 @@
     "node-addon-api": "^3.0.0",
     "node-gyp-build": "^4.2.1",
     "nyc": "^15.0.0",
-    "ref-napi": "^3.0.2"
+    "@rclnodejs/ref-napi": "^4.0.0"
   }
 }


### PR DESCRIPTION
Convert package to a scoped package under the @rclnodejs scope name. As a scoped package it will be less likely to be used for general purposes.